### PR TITLE
Update dependency checker

### DIFF
--- a/finalrecon.py
+++ b/finalrecon.py
@@ -21,8 +21,9 @@ if platform.system() == 'Linux':
 		pass
 else:
 	pass
+path_to_script = os.path.dirname(os.path.realpath(__file__))
 
-with open('requirements.txt', 'r') as rqr:
+with open(path_to_script + '/requirements.txt', 'r') as rqr:
 	pkg_list = rqr.read().strip().split('\n')
 
 print('\n' + G + '[+]' + C + ' Checking Dependencies...' + W + '\n')


### PR DESCRIPTION
Script fails when trying to run outside of FinalRecon folder. This commit provides an absolute path for "requirements.txt" no matter where the script is run from. 