### PR TITLE
Ubuntu 18.04 Path Error

### DIFF
--- a/finalrecon.py
+++ b/finalrecon.py
@@ -34,6 +34,7 @@ if os.path.exists(conf_path):
 	pass
 else:
 	import shutil
+	os.makedirs(conf_path + '/', exist_ok=True)
 	shutil.copytree(src_conf_path, conf_path, dirs_exist_ok=True)
 
 with open(path_to_script + '/requirements.txt', 'r') as rqr:


### PR DESCRIPTION
xxx@xxx:~/Ferramentas/FinalRecon$ python3 finalrecon.py 
Traceback (most recent call last):
  File "finalrecon.py", line 37, in <module>
    shutil.copytree(src_conf_path, conf_path, dirs_exist_ok=True)
TypeError: copytree() got an unexpected keyword argument 'dirs_exist_ok'