### PR TITLE
Psycopg2-binary library update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ lxml
 dnslib
 aiohttp
 aiodns
-psycopg2
+psycopg2-binary
 tldextract
 icmplib


### PR DESCRIPTION
When Installing requirement `psycopg2` throwing a Following Error `ERROR: No matching distribution found for psycopg2`
But This Could be Solved by Changing to the `psycopg2-binary` library by updating this Installation of requirements will be smooth and the tool can run.

For more Info Read Docs of Psycopg2: https://pypi.org/project/psycopg2/