### PR TITLE
Fix the dependency checker failing to recognise psycopg2-binary, and a few other things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,152 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/finalrecon.py
+++ b/finalrecon.py
@@ -24,7 +24,7 @@ if os.path.isfile(pid_path):
 		pid = pidfile.read()
 	print(G + '[+]' + C + ' PID : ' + W + str(pid))
 	print(G + '[>]' + C + ' If FinalRecon crashed, execute : ' + W + 'rm {}'.format(pid_path))
-	sys.exit()
+	sys.exit(1)
 else:
 	os.makedirs(os.path.dirname(pid_path), exist_ok=True)
 	with open(pid_path, 'w') as pidfile:
@@ -53,7 +53,7 @@ for pkg in pkg_list:
 if fail == True:
 	print('\n' + R + '[-]' + C + ' Please Execute ' + W + 'pip3 install -r requirements.txt' + C + ' to Install Missing Packages' + W + '\n')
 	os.remove(pid_path)
-	sys.exit()
+	sys.exit(1)
 
 import argparse
 
@@ -224,7 +224,7 @@ try:
 	if target.startswith(('http', 'https')) == False:
 		print(R + '[-]' + C + ' Protocol Missing, Include ' + W + 'http://' + C + ' or ' + W + 'https://' + '\n')
 		os.remove(pid_path)
-		sys.exit()
+		sys.exit(1)
 	else:
 		pass
 
@@ -249,7 +249,7 @@ try:
 		except Exception as e:
 			print ('\n' + R + '[-]' + C + ' Unable to Get IP : ' + W + str(e))
 			os.remove(pid_path)
-			sys.exit()
+			sys.exit(1)
 
 	start_time = datetime.datetime.now()
 
@@ -302,7 +302,7 @@ try:
 	elif subd == True and type_ip == True:
 		print(R + '[-]' + C + ' Sub-Domain Enumeration is Not Supported for IP Addresses' + W + '\n')
 		os.remove(pid_path)
-		sys.exit()
+		sys.exit(1)
 	else:
 		pass
 
@@ -326,7 +326,7 @@ try:
 		print ('\n' + R + '[-] Error : ' + C + 'At least One Argument is Required with URL' + W)
 		output = 'None'
 		os.remove(pid_path)
-		sys.exit()
+		sys.exit(1)
 
 	end_time = datetime.datetime.now() - start_time
 	print ('\n' + G + '[+]' + C + ' Completed in ' + W + str(end_time) + '\n')
@@ -344,4 +344,4 @@ try:
 except KeyboardInterrupt:
 	print (R + '[-]' + C + ' Keyboard Interrupt.' + W + '\n')
 	os.remove(pid_path)
-	sys.exit()
+	sys.exit(130)

--- a/finalrecon.py
+++ b/finalrecon.py
@@ -43,6 +43,8 @@ print('\n' + G + '[+]' + C + ' Checking Dependencies...' + W + '\n')
 
 for pkg in pkg_list:
 	spec = importlib.util.find_spec(pkg)
+	if spec is None and pkg == "psycopg2-binary":
+		spec = importlib.util.find_spec("psycopg2")
 	if spec is None:
 		print(R + '[-]' + W + ' {}'.format(pkg) + C + ' is not Installed!' + W)
 		fail = True

--- a/finalrecon.py
+++ b/finalrecon.py
@@ -39,22 +39,6 @@ else:
 with open(path_to_script + '/requirements.txt', 'r') as rqr:
 	pkg_list = rqr.read().strip().split('\n')
 
-print('\n' + G + '[+]' + C + ' Checking Dependencies...' + W + '\n')
-
-for pkg in pkg_list:
-	spec = importlib.util.find_spec(pkg)
-	if spec is None and pkg == "psycopg2-binary":
-		spec = importlib.util.find_spec("psycopg2")
-	if spec is None:
-		print(R + '[-]' + W + ' {}'.format(pkg) + C + ' is not Installed!' + W)
-		fail = True
-	else:
-		pass
-if fail == True:
-	print('\n' + R + '[-]' + C + ' Please Execute ' + W + 'pip3 install -r requirements.txt' + C + ' to Install Missing Packages' + W + '\n')
-	os.remove(pid_path)
-	sys.exit(1)
-
 import argparse
 
 version = '1.1.2'


### PR DESCRIPTION
This pull request fixes the dependency checker failing to recognise `psycopg2-binary` (which closes #48 )
I also:
* Added a standard .gitignore file for python, from [github/gitignore](https://github.com/github/gitignore/blob/main/Python.gitignore) (this should stop anyone from committing stuff they are not supposed to commit) 
* made the script exit with the code of 1 on errors (which is also pretty standard on unix systems and should make it integrate better with other software)