### PR TITLE
Fix/nonstandard port crawler

### DIFF
--- a/finalrecon.py
+++ b/finalrecon.py
@@ -233,7 +233,7 @@ try:
     port = split_url.port
     
     if type_ip:
-        netloc = f"{hostname}:{port}"
+        netloc = f"{hostname}:{port}" if port else hostname
         domain = ""
         domain_suffix = ""
     elif not private_ip:
@@ -245,7 +245,7 @@ try:
         netloc = f"{parsed_fqdn}:{port}" if port else parsed_fqdn
         apex_domain = f"{domain}.{domain_suffix}"
     else:
-        netloc = f"{hostname}:{port}"
+        netloc = f"{hostname}:{port}" if port else hostname
         domain = ""
         domain_suffix = ""
 

--- a/finalrecon.py
+++ b/finalrecon.py
@@ -236,6 +236,7 @@ try:
         netloc = f"{hostname}:{port}" if port else hostname
         domain = ""
         domain_suffix = ""
+        apex_domain = ""
     elif not private_ip:
         extractor = tldextract.TLDExtract()
         parsed_url = extractor.extract_urllib(split_url)
@@ -248,7 +249,8 @@ try:
         netloc = f"{hostname}:{port}" if port else hostname
         domain = ""
         domain_suffix = ""
-
+        apex_domain = ""
+        
     start_time = datetime.datetime.now()
 
     if output != "None":

--- a/finalrecon.py
+++ b/finalrecon.py
@@ -230,8 +230,10 @@ try:
 
     private_ip = ipaddress.ip_address(ip).is_private
 
+    port = split_url.port
+    
     if type_ip:
-        netloc = hostname
+        netloc = f"{hostname}:{port}"
         domain = ""
         domain_suffix = ""
     elif not private_ip:
@@ -239,10 +241,11 @@ try:
         parsed_url = extractor.extract_urllib(split_url)
         domain = parsed_url.domain
         domain_suffix = parsed_url.suffix
-        netloc = parsed_url.fqdn if parsed_url.fqdn else hostname
+        parsed_fqdn = parsed_url.fqdn if parsed_url.fqdn else hostname
+        netloc = f"{parsed_fqdn}:{port}" if port else parsed_fqdn
         apex_domain = f"{domain}.{domain_suffix}"
     else:
-        netloc = hostname
+        netloc = f"{hostname}:{port}"
         domain = ""
         domain_suffix = ""
 


### PR DESCRIPTION
# Fix: crawler fails to fetch robots.txt / sitemap.xml on non-standard ports

## Problem

When a target URL contains a non-standard port (e.g. `http://localhost:8888`),
the crawler module silently falls back to port 80 for `robots.txt` and `sitemap.xml`,
causing connection timeouts instead of fetching the correct URLs.

**Reproduction:**
```bash
python3 finalrecon.py --url http://localhost:8888 --crawl
```

**Observed error:**
```
[*] Looking for robots.txt
[-] Exception : HTTPConnectionPool(host='localhost', port=8888): Max retries exceeded
                with url: /robots.txt (Caused by ConnectTimeoutError(...))
```

## Root Cause

In `finalrecon.py`, `netloc` is constructed from either `split_url.hostname`
(via `urllib.parse.urlsplit`) or `tldextract`'s `.fqdn`.
Both strip the port number by design, so the port is silently lost before
being passed into `crawler()`.

```python
# Before – port is dropped in all three branches
split_url = parse.urlsplit(target)
hostname  = split_url.hostname        # "localhost"  (no port)

if type_ip:
    netloc = hostname                  # "localhost"
elif not private_ip:
    netloc = parsed_url.fqdn ...       # "localhost"
else:
    netloc = hostname                  # "localhost"
```

Inside `crawler.py` the URLs are then assembled as:
```python
r_url  = f"{protocol}://{netloc}/robots.txt"
# → "http://localhost/robots.txt"   ← port 80, wrong!
```

## Fix

Extract `split_url.port` once and append it to `netloc` in all three branches
when a non-standard port is present.

```python
port = split_url.port   # None for default ports (80 / 443)

if type_ip:
    netloc = f"{hostname}:{port}" if port else hostname

elif not private_ip:
    parsed_fqdn  = parsed_url.fqdn if parsed_url.fqdn else hostname
    netloc = f"{parsed_fqdn}:{port}" if port else parsed_fqdn

else:
    netloc = f"{hostname}:{port}" if port else hostname
```

`split_url.port` returns `None` when the URL uses the default port for its
scheme, so standard `http://localhost` and `https://localhost` targets
are completely unaffected.

Note: While testing this fix, a pre-existing `NameError: name 'apex_domain' is not defined` was also discovered. When the target is an IP address (`type_ip=True`) or a private IP (`else` branch), `apex_domain` is never defined but is later referenced in the `--full` scan path. A safe empty-string fallback has been added to both branches to prevent this crash.

## Testing

```bash
# Non-standard port – previously timed out on port 80
python3 finalrecon.py --url http://localhost:8888 --crawl

# Standard port – should still work as before
python3 finalrecon.py --url http://localhost --crawl
python3 finalrecon.py --url https://localhost --crawl
```